### PR TITLE
Fixed error in requirements

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+tqdm = "*"
+numpy = "*"
+scikit-learn = "*"
+torch = ">=1.4.0"
+transformers = "==3.4.0"
+
+[requires]
+python_version = "3.6"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 Data format descriptions are [here](https://github.com/NJUNLP/GTS/blob/main/data/datareadme.md).
 
 ## Requirements
-* pytorch=1.4.0
+See requirement.txt or Pipfile for details
+* pytorch==1.7.1
+* transformers==3.4.0
 * python=3.6
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,26 @@
+-i https://pypi.org/simple
+certifi==2020.12.5
+chardet==4.0.0
+click==7.1.2
+dataclasses==0.8 ; python_version < '3.7'
+filelock==3.0.12
+idna==2.10
+joblib==1.0.0
+numpy==1.19.5
+packaging==20.9
+protobuf==3.14.0
+pyparsing==2.4.7
+regex==2020.11.13
+requests==2.25.1
+sacremoses==0.0.43
+scikit-learn==0.24.1
+scipy==1.5.4
+sentencepiece==0.1.95
+six==1.15.0
+threadpoolctl==2.1.0
+tokenizers==0.9.2
+torch==1.7.1
+tqdm==4.56.0
+transformers==3.4.0
+typing-extensions==3.7.4.3
+urllib3==1.26.3


### PR DESCRIPTION
 I recently deployed this repo for running some aspect-sentiment triplet experiments on my own data.
 The requirements in the README.md are mistaken so I went to look for a combination of module versions that works.
 
I updated the README to reflect the correct dependencies.
I also added `requirements.txt` for use with `pip` and a `Pipfile` for use with `pipenv`.
 
Thank you for sharing this clean research code, the paper was a great read too!